### PR TITLE
Add initial support for double flats and sharps, flats and sharps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,16 @@
 PACKAGE := fux
 
-DEV_OPTIONS = --fast --ghc-options -freverse-errors --file-watch
+DEV_OPTIONS = --fast --ghc-options -freverse-errors
 
-.DEFAULT_GOAL := build
+.DEFAULT_GOAL := watch
 
 build:
 	stack build $(DEV_OPTIONS)
+
+watch:
+	stack build $(DEV_OPTIONS) --file-watch
+
+test:
+	stack test $(DEV_OPTIONS)
+
+.PHONY: build watch test

--- a/fux.cabal
+++ b/fux.cabal
@@ -76,3 +76,47 @@ library
       UndecidableInstances
   ghc-options: -Weverything -Wno-all-missed-specializations -Wno-implicit-prelude -Wno-missing-import-lists -Wno-missing-safe-haskell-mode -Wno-safe -Wno-unsafe
   default-language: Haskell2010
+
+test-suite fux-core
+  type: exitcode-stdio-1.0
+  main-is: Driver.hs
+  other-modules:
+      Test.Music.Fux.Pitch
+      Paths_fux
+  hs-source-dirs:
+      test/fux-core/
+  default-extensions:
+      BlockArguments
+      DataKinds
+      DeriveDataTypeable
+      DeriveFoldable
+      DeriveFunctor
+      DeriveTraversable
+      DerivingStrategies
+      FlexibleInstances
+      FunctionalDependencies
+      ImportQualifiedPost
+      LambdaCase
+      LexicalNegation
+      MultiWayIf
+      OverloadedStrings
+      PatternSynonyms
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StrictData
+      TupleSections
+      TypeApplications
+      TypeFamilies
+      TypeOperators
+      TypeSynonymInstances
+      ViewPatterns
+      UndecidableInstances
+  build-depends:
+      QuickCheck
+    , base
+    , fux
+    , tasty
+    , tasty-discover
+    , tasty-quickcheck
+  default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -13,19 +13,6 @@ build-type: Simple
 
 dependencies:
   - base
-  - containers
-  - logict
-  - megaparsec
-  - MonadRandom
-  - mtl
-  - normaldistribution
-  - parser-combinators
-  - pretty
-  - random
-  - template-haskell
-  - text
-  - transformers
-  - unicode
 
 default-extensions:
   - BlockArguments
@@ -55,15 +42,44 @@ default-extensions:
   - ViewPatterns
   - UndecidableInstances
 
-ghc-options:
-  - -Weverything
-  - -Wno-all-missed-specializations
-  - -Wno-implicit-prelude
-  - -Wno-missing-import-lists
-  - -Wno-missing-safe-haskell-mode
-  - -Wno-safe
-  - -Wno-unsafe
-
 library:
   source-dirs:
     - src/
+
+  dependencies:
+    - containers
+    - logict
+    - megaparsec
+    - MonadRandom
+    - mtl
+    - normaldistribution
+    - parser-combinators
+    - pretty
+    - random
+    - template-haskell
+    - text
+    - transformers
+    - unicode
+
+  ghc-options:
+    - -Weverything
+    - -Wno-all-missed-specializations
+    - -Wno-implicit-prelude
+    - -Wno-missing-import-lists
+    - -Wno-missing-safe-haskell-mode
+    - -Wno-safe
+    - -Wno-unsafe
+
+tests:
+  fux-core:
+    main: Driver.hs
+
+    source-dirs:
+      - test/fux-core/
+
+    dependencies:
+      - fux
+      - QuickCheck
+      - tasty
+      - tasty-discover
+      - tasty-quickcheck

--- a/src/Music/Fux/Pretty.hs
+++ b/src/Music/Fux/Pretty.hs
@@ -57,26 +57,29 @@ superscript :: Integral a => a -> Doc
 superscript = script Unicode.superscript
 
 pitchClass :: PitchClass -> Doc
-pitchClass = \case
-  C  -> char 'C'
-  Cs -> char 'C' <> char sharp
-  D  -> char 'D'
-  Ds -> char 'D' <> char sharp
-  E  -> char 'E'
-  F  -> char 'F'
-  Fs -> char 'F' <> char sharp
-  G  -> char 'G'
-  Gs -> char 'G' <> char sharp
-  A  -> char 'A'
-  As -> char 'A' <> char sharp
-  B  -> char 'B'
+pitchClass = pitchClassAnalysis (\n a -> docNote n <> docAccidental a)
+  where
+    docNote = char . \case
+      Do  -> 'C'
+      Re  -> 'D'
+      Mi  -> 'E'
+      Fa  -> 'F'
+      Sol -> 'G'
+      La  -> 'A'
+      Si  -> 'B'
+    docAccidental = \case
+      DoubleFlat  -> char doubleFlat
+      Flat        -> char flat
+      Natural     -> mempty
+      Sharp       -> char sharp
+      DoubleSharp -> char doubleSharp
 
 duration :: Rational -> Doc
 duration r
   | denominator r == 1 = superscript $ numerator r
   | otherwise          = superscript (numerator r) <+> superscript (denominator r)
 
-pitch :: Pitch -> Doc
+pitch :: Pitch PitchClass -> Doc
 pitch (Pitch pc o) = pitchClass pc <> subscript o
 
 voice :: (a -> Doc) -> Voice a -> Doc

--- a/src/Music/Fux/Types.hs
+++ b/src/Music/Fux/Types.hs
@@ -275,9 +275,25 @@ data Solfège
   = Do | Re | Mi | Fa | Sol | La | Si
   deriving stock (Bounded, Data, Enum, Eq, Ord, Show)
 
+instance Uniform Solfège where
+  uniformM = uniformRM (minBound, maxBound)
+
+instance UniformRange Solfège where
+  uniformRM (l, h) g = toEnum <$> uniformRM (fromEnum l, fromEnum h) g
+
+instance Random Solfège
+
 data Accidental
   = DoubleFlat | Flat | Natural | Sharp | DoubleSharp
   deriving stock (Bounded, Data, Enum, Eq, Ord, Show)
+
+instance Uniform Accidental where
+  uniformM = uniformRM (minBound, maxBound)
+
+instance UniformRange Accidental where
+  uniformRM (l, h) g = toEnum <$> uniformRM (fromEnum l, fromEnum h) g
+
+instance Random Accidental
 
 pitchClassAnalysis :: (Solfège -> Accidental -> a) -> PitchClass -> a
 pitchClassAnalysis f p = uncurry f $ bimap toEnum toEnum $ quotRem (fromEnum p) 5
@@ -435,7 +451,7 @@ simpleInterval :: Pitch SimplePitchClass -> Pitch SimplePitchClass -> CompoundIn
 simpleInterval (Pitch n1 o1) (Pitch n2 o2) =
   case compare n1 n2 of
     LT -> case compare o1 o2 of
-      LT -> CompoundInterval  octaveDiff      (toEnum $      fromEnum n2 - fromEnum n1)
+      LT -> CompoundInterval (octaveDiff - 1) (toEnum $      fromEnum n2 - fromEnum n1)
       EQ -> CompoundInterval  octaveDiff      (toEnum $      fromEnum n2 - fromEnum n1)
       GT -> CompoundInterval (octaveDiff - 1) (toEnum $ 12 + fromEnum n1 - fromEnum n2)
     EQ -> CompoundInterval octaveDiff Pe1'

--- a/src/Music/Fux/Types.hs
+++ b/src/Music/Fux/Types.hs
@@ -26,9 +26,17 @@ module Music.Fux.Types
 
     -- * Pitch
   , PitchClass (..)
-  , pattern Ab, pattern Bb, pattern Db, pattern Eb, pattern Gb
+  , SimplePitchClass (..)
   , Pitch (..)
   , transposeSemitones
+  , simpleToComplexPitch
+  , complexToSimplePitch
+  , simpleToComplexPitchClass
+  , complexToSimplePitchClass
+  , Solfège (..)
+  , Accidental (..)
+  , pitchClassAnalysis
+  , solfègeAnalysis
 
     -- * Key
   , Key (..)
@@ -54,6 +62,7 @@ module Music.Fux.Types
   , CompoundInterval (..)
   , interval'
   , interval
+  , simpleInterval
 
   , Sonance (..)
   , sonance'
@@ -109,64 +118,97 @@ instance Monoid (Music a) where
 
 -- | The absolute pitch. It's the combination of some pitch class and the octave
 -- where it's located.
-data Pitch = Pitch
-  { pPitchClass :: PitchClass  -- ^ The musical note to which this pitch corresponds to,
+data Pitch pitchClass = Pitch
+  { pPitchClass :: pitchClass  -- ^ The musical note to which this pitch corresponds to,
   , pOctave     :: Octave  -- ^ The octave of this pitch.
   } deriving stock (Data, Eq, Show)
 
-instance Ord Pitch where
+instance Ord pitchClass => Ord (Pitch pitchClass) where
   compare (Pitch pc1 o1) (Pitch pc2 o2) = compare o1 o2 <> compare pc1 pc2
 
-instance Enum Pitch where
+instance Enum (Pitch SimplePitchClass) where
   fromEnum (Pitch o p) = fromEnum p * 12 + fromEnum o
   toEnum i = Pitch (toEnum p) (toEnum o)
     where
       (o, p) = i `quotRem` 12
 
-instance Uniform Pitch where
+instance Uniform pitchClass => Uniform (Pitch pitchClass) where
   uniformM g = Pitch <$> uniformM g <*> uniformRM (0, 8) g
 
--- | Whole-tone, chromatic natural and sharp notes.
+-- | Simply changes the pitch class by calling 'simpleToComplexPitchClass'.
+simpleToComplexPitch :: Pitch SimplePitchClass -> Pitch PitchClass
+simpleToComplexPitch (Pitch n o) = Pitch (simpleToComplexPitchClass n) o
+
+-- | Calls 'complexToSimplePitchClass' on the pitch component, but in addition,
+-- also normalizes the octave, so that a C𝄫₃, for example, becomes an A♯₂.
+complexToSimplePitch :: Pitch PitchClass -> Pitch SimplePitchClass
+complexToSimplePitch (Pitch n o) = Pitch (complexToSimplePitchClass n) o'
+  where
+    o' = case n of
+      Cbb -> o - 1
+      Cb  -> o - 1
+      Bs  -> o + 1
+      Bss -> o + 1
+      _   -> o
+
+-- | Converts a simple to a complex pitch. The relation is preserved, that is,
+-- sharps remain as sharps and naturals as naturals, and the base note doesn't
+-- change. No attempt to add double flats, flats or double sharps is made.
+simpleToComplexPitchClass :: SimplePitchClass -> PitchClass
+simpleToComplexPitchClass = \case
+  { C' -> C; Cs' -> Cs
+  ; D' -> D; Ds' -> Ds
+  ; E' -> E
+  ; F' -> F; Fs' -> Fs
+  ; G' -> G; Gs' -> Gs
+  ; A' -> A; As' -> As
+  ; B' -> B
+  }
+
+-- | "Forgets" double flats, flats and double sharps by transforming into a
+-- 'SimplePitchClass', which contains only naturals and sharps.
+complexToSimplePitchClass :: PitchClass -> SimplePitchClass
+complexToSimplePitchClass = \case
+  { Cbb -> As'; Cb -> B' ; C -> C'; Cs -> Cs'; Css -> D'
+  ; Dbb -> C' ; Db -> Cs'; D -> D'; Ds -> Ds'; Dss -> E'
+  ; Ebb -> D' ; Eb -> Ds'; E -> E'; Es -> F' ; Ess -> Fs'
+  ; Fbb -> Ds'; Fb -> E' ; F -> F'; Fs -> Fs'; Fss -> G'
+  ; Gbb -> F' ; Gb -> Fs'; G -> G'; Gs -> Gs'; Gss -> A'
+  ; Abb -> G' ; Ab -> Gs'; A -> A'; As -> As'; Ass -> B'
+  ; Bbb -> A' ; Bb -> As'; B -> B'; Bs -> C' ; Bss -> Cs'
+  }
+
+-- | Whole-tone, chromatic natural and accidental notes.
 data PitchClass
-  = C | Cs
-  | D | Ds
-  | E
-  | F | Fs
-  | G | Gs
-  | A | As
-  | B
+  = Cbb | Cb | C | Cs | Css
+  | Dbb | Db | D | Ds | Dss
+  | Ebb | Eb | E | Es | Ess
+  | Fbb | Fb | F | Fs | Fss
+  | Gbb | Gb | G | Gs | Gss
+  | Abb | Ab | A | As | Ass
+  | Bbb | Bb | B | Bs | Bss
   deriving stock (Bounded, Data, Eq, Ord, Show)
 
 instance Enum PitchClass where
   fromEnum = \case
-    { C -> 0; Cs -> 1
-    ; D -> 2; Ds -> 3
-    ; E -> 4
-    ; F -> 5; Fs -> 6
-    ; G -> 7; Gs -> 8
-    ; A -> 9; As -> 10
-    ; B -> 11
+    { Cbb ->  0; Cb ->  1; C ->  2; Cs ->  3; Css ->  4
+    ; Dbb ->  5; Db ->  6; D ->  7; Ds ->  8; Dss ->  9
+    ; Ebb -> 10; Eb -> 11; E -> 12; Es -> 13; Ess -> 14
+    ; Fbb -> 15; Fb -> 16; F -> 17; Fs -> 18; Fss -> 19
+    ; Gbb -> 20; Gb -> 21; G -> 22; Gs -> 23; Gss -> 24
+    ; Abb -> 25; Ab -> 26; A -> 27; As -> 28; Ass -> 29
+    ; Bbb -> 30; Bb -> 31; B -> 32; Bs -> 33; Bss -> 34
     }
-  toEnum i = case i `mod` 12 of
-    { 0 -> C; 1 -> Cs
-    ; 2 -> D; 3 -> Ds
-    ; 4 -> E
-    ; 5 -> F; 6 -> Fs
-    ; 7 -> G; 8 -> Gs
-    ; 9 -> A; 10 -> As
-    ; 11 -> B
+  toEnum i = case i `mod` 35 of
+    {  0 -> Cbb;  1 -> Cb;  2 -> C;  3 -> Cs;  4 -> Css
+    ;  5 -> Dbb;  6 -> Db;  7 -> D;  8 -> Ds;  9 -> Dss
+    ; 10 -> Ebb; 11 -> Eb; 12 -> E; 13 -> Es; 14 -> Ess
+    ; 15 -> Fbb; 16 -> Fb; 17 -> F; 18 -> Fs; 19 -> Fss
+    ; 20 -> Gbb; 21 -> Gb; 22 -> G; 23 -> Gs; 24 -> Gss
+    ; 25 -> Abb; 26 -> Ab; 27 -> A; 28 -> As; 29 -> Ass
+    ; 30 -> Bbb; 31 -> Bb; 32 -> B; 33 -> Bs; 34 -> Bss
     ; _ -> error "impossible"
     }
-
--- | Transpose some pitch by the provided number of semitones. A negative number
--- transposes down and a positive number transposes up.
-transposeSemitones :: Int -> Pitch -> Pitch
-transposeSemitones steps pitch =
-  snd $ fix (\rec (i, x) -> if i == 0 then (i, x) else rec (i - 1, f x)) (abs steps, pitch)
-  where
-    f | steps <  0 = pred
-      | steps == 0 = id
-      | otherwise  = succ
 
 instance Uniform PitchClass where
   uniformM = uniformRM (minBound, maxBound)
@@ -176,12 +218,72 @@ instance UniformRange PitchClass where
 
 instance Random PitchClass
 
-pattern Ab, Bb, Db, Eb, Gb :: PitchClass
-pattern Ab = Gs
-pattern Bb = As
-pattern Db = Cs
-pattern Eb = Ds
-pattern Gb = Fs
+-- | Whole-tone, chromatic natural and sharp notes.
+--
+-- This exists to simplify various operations when working with 'PitchClass',
+-- such as calculating intervals.
+data SimplePitchClass
+  = C' | Cs'
+  | D' | Ds'
+  | E'
+  | F' | Fs'
+  | G' | Gs'
+  | A' | As'
+  | B'
+  deriving stock (Bounded, Data, Eq, Ord, Show)
+
+instance Enum SimplePitchClass where
+  fromEnum = \case
+    { C' ->  0; Cs' ->  1
+    ; D' ->  2; Ds' ->  3
+    ; E' ->  4
+    ; F' ->  5; Fs' ->  6
+    ; G' ->  7; Gs' ->  8
+    ; A' ->  9; As' -> 10
+    ; B' -> 11
+    }
+  toEnum i = case i `mod` 12 of
+    {  0 -> C';  1 -> Cs'
+    ;  2 -> D';  3 -> Ds'
+    ;  4 -> E'
+    ;  5 -> F';  6 -> Fs'
+    ;  7 -> G';  8 -> Gs'
+    ;  9 -> A'; 10 -> As'
+    ; 11 -> B'
+    ; _ -> error "impossible"
+    }
+
+-- | Transpose some pitch by the provided number of semitones. A negative number
+-- transposes down and a positive number transposes up.
+transposeSemitones :: Int -> Pitch SimplePitchClass -> Pitch SimplePitchClass
+transposeSemitones steps pitch =
+  snd $ fix (\rec (i, x) -> if i == 0 then (i, x) else rec (i - 1, f x)) (abs steps, pitch)
+  where
+    f | steps <  0 = pred
+      | steps == 0 = id
+      | otherwise  = succ
+
+instance Uniform SimplePitchClass where
+  uniformM = uniformRM (minBound, maxBound)
+
+instance UniformRange SimplePitchClass where
+  uniformRM (l, h) g = toEnum <$> uniformRM (fromEnum l, fromEnum h) g
+
+instance Random SimplePitchClass
+
+data Solfège
+  = Do | Re | Mi | Fa | Sol | La | Si
+  deriving stock (Bounded, Data, Enum, Eq, Ord, Show)
+
+data Accidental
+  = DoubleFlat | Flat | Natural | Sharp | DoubleSharp
+  deriving stock (Bounded, Data, Enum, Eq, Ord, Show)
+
+pitchClassAnalysis :: (Solfège -> Accidental -> a) -> PitchClass -> a
+pitchClassAnalysis f p = uncurry f $ bimap toEnum toEnum $ quotRem (fromEnum p) 5
+
+solfègeAnalysis :: (PitchClass -> a) -> Solfège -> Accidental -> a
+solfègeAnalysis f note accidental = f $ toEnum $ fromEnum note * 5 + fromEnum accidental
 
 -- | Represents the key for some scale, chord or signature.
 data Key
@@ -232,8 +334,8 @@ defaultAscScaleImplementationForWholeToneKey pitch = \case
     (doM, reM, miM, faM, soM, laM, tiM, doM') =
       (pitch, ss doM, ss reM, s miM, ss faM, ss soM, ss laM, s tiM)
 
-instance Scale PitchClass Key where
-  type PitchClassFor PitchClass = PitchClass
+instance Scale SimplePitchClass Key where
+  type PitchClassFor SimplePitchClass = SimplePitchClass
 
   desScaleFor = defaultDesScaleImplementationForWholeToneKey
   ascScaleFor = defaultAscScaleImplementationForWholeToneKey
@@ -244,8 +346,8 @@ instance Scale PitchClass Key where
     where
       s = ascScaleFor base mode
 
-instance Scale Pitch Key where
-  type PitchClassFor Pitch = PitchClass
+instance Scale (Pitch SimplePitchClass) Key where
+  type PitchClassFor (Pitch SimplePitchClass) = SimplePitchClass
 
   desScaleFor = defaultDesScaleImplementationForWholeToneKey
   ascScaleFor = defaultAscScaleImplementationForWholeToneKey
@@ -321,12 +423,16 @@ pattern Au7 = Pe8
 pattern Di8 = Ma7
 
 -- | Calculate the simple interval between two pitches.
-interval' :: Pitch -> Pitch -> Interval
+interval' :: Pitch PitchClass -> Pitch PitchClass -> Interval
 interval' p1 p2 = ciInterval $ interval p1 p2
 
 -- | Calculate the compound interval between two pitches.
-interval :: Pitch -> Pitch -> CompoundInterval
-interval (Pitch n1 o1) (Pitch n2 o2) =
+interval :: Pitch PitchClass -> Pitch PitchClass -> CompoundInterval
+interval p1 p2 = simpleInterval (complexToSimplePitch p1) (complexToSimplePitch p2)
+
+-- | Calculate the compound interval between two simple pitches.
+simpleInterval :: Pitch SimplePitchClass -> Pitch SimplePitchClass -> CompoundInterval
+simpleInterval (Pitch n1 o1) (Pitch n2 o2) =
   case compare n1 n2 of
     LT -> case compare o1 o2 of
       LT -> CompoundInterval  octaveDiff      (toEnum $      fromEnum n2 - fromEnum n1)

--- a/test/fux-core/Driver.hs
+++ b/test/fux-core/Driver.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF tasty-discover -optF --hide-successes -optF --tree-display #-}

--- a/test/fux-core/Test/Music/Fux/Pitch.hs
+++ b/test/fux-core/Test/Music/Fux/Pitch.hs
@@ -1,0 +1,53 @@
+-- Copyright (c) 2021, Heitor Toledo Lassarote de Paula
+--
+-- This file is part of fux.
+--
+--     fux is free software: you can redistribute it and/or modify
+--     it under the terms of the GNU General Public License as published by
+--     the Free Software Foundation, either version 3 of the License, or
+--     (at your option) any later version.
+--
+--     fux is distributed in the hope that it will be useful,
+--     but WITHOUT ANY WARRANTY; without even the implied warranty of
+--     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--     GNU General Public License for more details.
+--
+--     You should have received a copy of the GNU General Public License
+--     along with fux.  If not, see <https://www.gnu.org/licenses/>.
+module Test.Music.Fux.Pitch
+  ( prop_pitchClassAnalysisAfterSolfègeAnalysisIsIdentity
+  , prop_solfègeAnalysisAfterPitchClassAnalysisIsIdentity
+  , prop_intervalIsSymmetric
+  ) where
+
+import Music.Fux.Types
+
+import Test.QuickCheck.Arbitrary
+import Test.QuickCheck.Gen
+
+-- TODO: Refactor instances to common module when needed.
+instance Arbitrary SimplePitchClass where
+  arbitrary = chooseAny
+
+instance Arbitrary PitchClass where
+  arbitrary = chooseAny
+
+instance Arbitrary Solfège where
+  arbitrary = chooseAny
+
+instance Arbitrary Accidental where
+  arbitrary = chooseAny
+
+instance Arbitrary pitchClass => Arbitrary (Pitch pitchClass) where
+  arbitrary = Pitch <$> arbitrary <*> arbitrary
+
+prop_pitchClassAnalysisAfterSolfègeAnalysisIsIdentity :: PitchClass -> Bool
+prop_pitchClassAnalysisAfterSolfègeAnalysisIsIdentity pitchClass =
+  uncurry (solfègeAnalysis id) (pitchClassAnalysis (,) pitchClass) == pitchClass
+
+prop_solfègeAnalysisAfterPitchClassAnalysisIsIdentity :: Solfège -> Accidental -> Bool
+prop_solfègeAnalysisAfterPitchClassAnalysisIsIdentity note accidental =
+  pitchClassAnalysis (,) (solfègeAnalysis id note accidental) == (note, accidental)
+
+prop_intervalIsSymmetric :: Pitch PitchClass -> Pitch PitchClass -> Bool
+prop_intervalIsSymmetric p1 p2 = interval p1 p2 == interval p2 p1


### PR DESCRIPTION
This MR adds basic support for using double flats, double sharps and flats. Previously, only naturals and sharps were supported. Note that the generators still use the old natural/sharp system.